### PR TITLE
Python3 compatibility

### DIFF
--- a/object_detector_retinanet/keras_retinanet/bin/predict.py
+++ b/object_detector_retinanet/keras_retinanet/bin/predict.py
@@ -21,7 +21,6 @@ import os
 import sys
 
 import keras
-import numpy
 import tensorflow as tf
 
 

--- a/object_detector_retinanet/keras_retinanet/utils/CollapsingMoG.py
+++ b/object_detector_retinanet/keras_retinanet/utils/CollapsingMoG.py
@@ -187,7 +187,7 @@ def min_kl(beta, cov_, covariance_prime, mu_, mu_prime):
 
 
 def m_step(alpha, beta, clusters, covariance, covariance_prime, mu, mu_prime):
-    for j, t_vals in clusters.iteritems():
+    for j, t_vals in clusters.items():
         beta_update = 0
         for t in t_vals:
             beta_update += alpha[t]

--- a/object_detector_retinanet/keras_retinanet/utils/predict_iou.py
+++ b/object_detector_retinanet/keras_retinanet/utils/predict_iou.py
@@ -83,7 +83,7 @@ def predict(
         filtered_scores = []
         filtered_labels = []
 
-        for ind, detection in filtered_data.iterrows():
+        for _, detection in filtered_data.iterrows():
             box = np.asarray([detection['x1'], detection['y1'], detection['x2'], detection['y2']])
             filtered_boxes.append(box)
             filtered_scores.append(detection['confidence'])
@@ -108,7 +108,7 @@ def predict(
         print('{}/{}'.format(i + 1, generator.size()), end='\r')
 
     # Save annotations csv file
-    with open(res_file, 'wb') as fl_csv:
+    with open(res_file, 'w') as fl_csv:
         writer = csv.writer(fl_csv)
         writer.writerows(csv_data_lst)
     print("Saved output.csv file")

--- a/object_detector_retinanet/utils.py
+++ b/object_detector_retinanet/utils.py
@@ -1,6 +1,4 @@
-import logging
 import os
-import sys
 import platform
 
 __author__ = 'roeiherz'
@@ -9,7 +7,7 @@ FILE_EXISTS_ERROR = (17, 'File exists')
 
 IMG_FOLDER = 'images'
 ANNOTATION_FOLDER = 'annotations'
-DEBUG_MODE = False #'ubuntu' not in os.environ['HOME']
+DEBUG_MODE = False # 'ubuntu' not in os.environ['HOME']
 if DEBUG_MODE:
     IMG_FOLDER += '_debug'
     ANNOTATION_FOLDER += '_debug'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Keras==2.2.5
+keras-retinanet==0.5.1
+tensorflow-gpu==1.14.0
+numpy==1.19.2
+opencv-python==3.1.0.5
+tqdm==4.50.2
+pandas==0.23.4


### PR DESCRIPTION
## Context
This PR is about the issues encountered here: #79 

## What was done

- Flake8 suggestions
  - I've removed some unused imports and variables as a suggestion on executing flake8:  `flake8 file.py` 
- Python3 compatibility
  - Removed iteritems() method and 'wb' from open CSV due to incompatibility as I sad in #79 
- Requirements file
  - Added requirements file to easily install the dependencies, I tested the **predict.py** with a new virtualenv after using `pip3 install requirements.txt` and everything worked fine!